### PR TITLE
修复（extract_pdf）：防止大图像的过度缩放

### DIFF
--- a/modules/extract_pdf.py
+++ b/modules/extract_pdf.py
@@ -12,8 +12,8 @@ def load_pdf_fitz(pdf_path, dpi=72):
         mat = fitz.Matrix(dpi / 72, dpi / 72)
         pm = page.get_pixmap(matrix=mat, alpha=False)
 
-        # if width or height > 3000 pixels, don't enlarge the image
-        if pm.width > 3000 or pm.height > 3000:
+        # If the width or height exceeds 9000 after scaling, do not scale further.
+        if pm.width > 9000 or pm.height > 9000:
             pm = page.get_pixmap(matrix=fitz.Matrix(1, 1), alpha=False)
 
         img = Image.frombytes("RGB", (pm.width, pm.height), pm.samples)


### PR DESCRIPTION
Adjust the condition to prevent images from being enlarged beyond a width or height of 9000 pixels, ensuring large images do not become overly large when processed. This change avoids unnecessary resource consumption and potential performance issues when handling scaled images.