### PR TITLE
feat: add num-workers parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,6 +264,7 @@ Parameter explanations:
 - `--vis`: Whether to visualize the results; if yes, detection results including bounding boxes and categories will be visualized.
 - `--render`: Whether to render the recognized results, including LaTeX code for formulas and plain text, which will be rendered and placed in the detection boxes. Note: This process is very time-consuming, and also requires prior installation of `xelatex` and `imagemagic`.
 - `--batch-size`: Batch size for dataloader. Larger batch sizes are recommended, but smaller sizes require less GPU memory. Default is 128.
+- `--num-workers`: Workers to preload data. 0 means main process will do data loading. Otherwise workers will speed up I/O process by consuming memory. Default is 32.
 
 > This project is dedicated to using models for high-quality content extraction from documents on diversity. It does not involve reassembling the extracted content into new documents, such as converting PDFs to Markdown. For those needs, please refer to our other GitHub project: [MinerU](https://github.com/opendatalab/MinerU)
 

--- a/pdf_extract.py
+++ b/pdf_extract.py
@@ -79,6 +79,7 @@ if __name__ == '__main__':
     parser.add_argument('--pdf', type=str)
     parser.add_argument('--output', type=str, default="output")
     parser.add_argument('--batch-size', type=int, default=128)
+    parser.add_argument('--num-workers', type=int, default=32)
     parser.add_argument('--vis', action='store_true')
     parser.add_argument('--render', action='store_true')
     args = parser.parse_args()
@@ -157,7 +158,7 @@ if __name__ == '__main__':
         # Formula recognition, collect all formula images in whole pdf file, then batch infer them.
         a = time.time()  
         dataset = MathDataset(mf_image_list, transform=mfr_transform)
-        dataloader = DataLoader(dataset, batch_size=args.batch_size, num_workers=32)
+        dataloader = DataLoader(dataset, batch_size=args.batch_size, num_workers=args.num_workers)
         mfr_res = []
         for imgs in dataloader:
             imgs = imgs.to(device)


### PR DESCRIPTION
Added a `num-workers` parameter, to give some command line flexibility for GPUs with smaller RAM sizes, because Dataloader workers can use a lot of memory while prefetching data.

`README.md` was updated, however `README-zh_CN.md` should also be updated.